### PR TITLE
kv-subject-name wildcard

### DIFF
--- a/adr/ADR-8.md
+++ b/adr/ADR-8.md
@@ -193,7 +193,7 @@ Here is a full example of the `CONFIGURATION` bucket:
 {
   "name": "KV_CONFIGURATION",
   "subjects": [
-    "$KV.CONFIGURATION.>"
+    "$KV.CONFIGURATION.*"
   ],
   "retention": "limits",
   "max_consumers": -1,


### PR DESCRIPTION
Use the cli command `nats kv add foo`, then do `nats s info KV_foo`,  the subject is `.*` not `.>` so assuming the docs should match the cli.

```
>nats s info KV_foo
Information for Stream KV_foo created 2021-08-07T16:49:16-04:00

Configuration:

             Subjects: $KV.foo.*
```