### PR TITLE
ADR-24 Restricted Inbox

### DIFF
--- a/adr/ADR-24.md
+++ b/adr/ADR-24.md
@@ -1,0 +1,17 @@
+# Restricted Inbox  
+
+|Metadata| Value                     |
+|--------|---------------------------|
+|Date    | 2022-06-29                |
+|Author  | @tbeets, @derekcollison>  |
+|Status  | `Proposed`                |
+|Tags    | client, server |
+
+## Context and Problem Statement
+
+For ertain use cases, there is a need for server-enforced configurability such that a service responder's reply message published
+to the requester's REPLY subject can only be subscribed by the requesting NATS client.
+
+## Design
+
+TODO


### PR DESCRIPTION
PR created for visibility on [ADR-24](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-24.md) in-process branch. [ADR-24](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-24.md) defines a new feature to create a server-enforced restricted inbox that only a specific connected client can subscribe to. The PR should be approved only when [ADR-24](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-24.md) specification is complete.