### PR TITLE
Update ADR 8 KV Status interface

### DIFF
--- a/adr/ADR-8.md
+++ b/adr/ADR-8.md
@@ -115,6 +115,9 @@ type Status interface {
 
 	// BackingStore is a name indicating the kind of backend
 	BackingStore() string
+
+    // Bytes returns the size in bytes of the bucket
+    Bytes() uint64
 }
 ```
 


### PR DESCRIPTION
Adds `Bytes()` to the bucket Status interface (see https://github.com/nats-io/nats.go/pull/1092)