### PR TITLE
ADR-4 Proposal: alternate character encodings in headers

### DIFF
--- a/adr/ADR-4.md
+++ b/adr/ADR-4.md
@@ -52,6 +52,9 @@ Any case sensitivity in header interpretation is the responsibility of the appli
 
 > Note: This is _different_ from HTTP headers which declare/define that web server and user-agent participants should ignore case.
 
+###### Character Encoding
+NATS Clients _may_ offer alternate header key and value encodings that are backward-compatible with ASCII.  NATS Clients _should_ use a default header key and value encoding of either UTF-8 (preferred) or ASCII.
+
 With above caveats, please refer to the
 [specification](https://tools.ietf.org/html/rfc7230#section-3.2) for information
 on how to encode/decode HTTP headers.


### PR DESCRIPTION
NATS users may want to send header keys and values other in encodings other than ASCII.  This is especially popular in languages other than English.

Highlight that header key/value encodings that are backward-compatible with ASCII can optionally be offered by NATS Clients.

Allow clients to select UTF-8 as their default encoding, and annotate that UTF-8 is the preferred character encoding.

Understandably, client implementations may rely on HTTP header parsing libraries that enforce ASCII.  For this reason, and also for backward compatibility reasons, ASCII should remain a valid default encoding option.