### PR TITLE
[adr-32] add meta field to service api

### DIFF
--- a/adr/ADR-32.md
+++ b/adr/ADR-32.md
@@ -25,6 +25,7 @@ Service configuration relies on the following:
   `A-Z, a-z, 0-9, dash, underscore`.
 - `version` - a SemVer string - impl should validate that this is SemVer
 - `description` - a human-readable description about the service (optional)
+- `meta` - meta data about the service (optional)
 - `schema`: (optional)
   - `request` - a string/url describing the format of the request payload can be
     JSON schema etc.
@@ -106,6 +107,10 @@ All discovery and status responses contain the following fields:
     * The version of the service
     */
     version: string
+    /**
+    * an object containing meta data (optional) ex: {"mac":"aa:bb:cc:dd:ee:ff","count":123}
+    */
+    meta?: Record<string, any>
 }
 ```
 
@@ -127,6 +132,10 @@ Returns a JSON having the following structure:
      */
     version: string,
     /**
+    * an object containing meta data (optional) ex: {"mac":"aa:bb:cc:dd:ee:ff","count":123}
+    */
+    meta?: Record<string, any>
+    /**
      * Subject where the service can be invoked
      */
     subject: string
@@ -146,6 +155,7 @@ Returns the following schema (the standard response fields)
     name: string,
     id: string,
     version: string,
+    meta?: Record<string, any>
 }
 ```
 
@@ -162,6 +172,7 @@ only returned if the `schema` was specified when created.
     name: string,
     id: string,
     version: string,
+    meta?: Record<string, any>
     /**
      * The schema specified when the service was created
      */
@@ -185,6 +196,7 @@ only returned if the `schema` was specified when created.
     name: string,
     id: string,
     version: string,
+    meta?: Record<string, any>
     /**
     * The number of requests received by the endpoint
     */


### PR DESCRIPTION
I added an optional meta field to the service definition, this allows to specify some optional meta data to a service instance, like for instance, the Mac address of the machine running the service.

The format is a map in the form {"label": value} where value can be any json type.

I suppose that the typescript definition would be (but I'm not totally sure of that) :
```typescript
meta?: Record<string, any>
```