### PR TITLE
Change INFO response to contain endpoint details

### DIFF
--- a/adr/ADR-32.md
+++ b/adr/ADR-32.md
@@ -133,15 +133,26 @@ Returns a JSON having the following structure:
      */
     description: string,
     /**
-     * An array of all endpoint subjects
+     * An array of info for all service endpoints
      */
-    subjects: string[]
+    endpoints: EndpointInfo[]
+}
+```
+
+```typescript
+// EndpointInfo
+{
+    name: string,
+    subject: string,
+    /**
+     * Metadata of a specific endpoint
+     */
+    metadata: Record<string,string>,
 }
 ```
 
 All the fields above map 1-1 to the metadata provided when the service was
-created. Note that `subjects` is a list of all subjects on which endpoints were
-registered.
+created.
 
 The type for this is `io.nats.micro.v1.info_response`.
 
@@ -210,10 +221,6 @@ The type for this is `io.nats.micro.v1.ping_response`.
     * The subject on which the endpoint is registered
     */
     subject: string;
-    /**
-     * Endpoint specific metadata
-     */
-    metadata: Record<string,string>;
     /**
     * The number of requests received by the endpoint
     */


### PR DESCRIPTION
- Remove endpoint metadata from `io.nats.micro.v1.stats_response` response
- Replace `subjects []string` with `endpoints []EndpointInfo` in `io.nats.micro.v1.info_response` (includes endpoint name, subject and endpoint metadata)