### PR TITLE
Refocus ADR repo around specifications

### DIFF
--- a/.readme.templ
+++ b/.readme.templ
@@ -2,7 +2,7 @@
 
 # NATS Architecture And Design
 
-This repo is used to capture architectural and design decisions as a reference of the server implementation and expected client behavior.
+This repository captures Architecture, Design Specifications and Feature Guidance for the NATS ecosystem.
 
 # Architecture Decision Records
 {{- range . }}
@@ -16,29 +16,16 @@ This repo is used to capture architectural and design decisions as a reference o
 {{ end }}
 ## When to write an ADR
 
-Not every little decision needs an ADR, and we are not overly prescriptive about the format apart from the initial header format.
-The kind of change that should have an ADR are ones likely to impact many client libraries, server configuration, security, deployment
-and those where we specifically wish to solicit wider community input.
+We use this repository in a few ways:
 
-For a background of the rationale driving ADRs see [Documenting Architecture Decisions](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) by
-Michael Nygard
+ 1. Design specifications where a single document captures everything about a feature, examples are ADR-8, ADR-32, ADR-37 and ADR-40
+ 1. Guidance on conventions and design such as ADR-6 which documents all the valid naming rules
+ 1. Capturing design that might impact many areas of the system such as ADR-2
+
+We want to move away from using these to document individual minor decisions, moving instead to spec like documents that are living documents and can change over time. Each capturing revisions and history.
 
 ## Template
 
 Please see the [template](adr-template.md). The template body is a guideline. Feel free to add sections as you feel appropriate. Look at the other ADRs for examples. However the initial Table of metadata and header format is required to match.
 
 After editing / adding a ADR please run `go run main.go > README.md` to update the embedded index. This will also validate the header part of your ADR.
-
-## Related Repositories
-
- * Server [nats-server](https://github.com/nats-io/nats-server)
- * Reference implementation [nats.go](https://github.com/nats-io/nats.go)
- * Java Client [nats.java](https://github.com/nats-io/nats..java)
- * .NET / C# client [nats.net](https://github.com/nats-io/nats.net)
- * JavaScript [nats.ws](https://github.com/nats-io/nats.ws) [nats.deno](https://github.com/nats-io/nats.deno)
- * C Client [nats.c](https://github.com/nats-io/nats.c)
- * Python3 Client for Asyncio [nats.py](https://github.com/nats-io/nats.py)
-
-### Client Tracking
-
-There is a [Client Feature Parity](https://docs.google.com/spreadsheets/d/1VcYcKqwOp8h8zZwNSRXMS5wrdA1jZz6AumMTHZbXrmY/edit#gid=1032495336) spreadsheet that tracks the clients somewhat, but it is not guaranteed to be complete or up to date.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # NATS Architecture And Design
 
-This repo is used to capture architectural and design decisions as a reference of the server implementation and expected client behavior.
+This repository captures Architecture, Design Specifications and Feature Guidance for the NATS ecosystem.
 
 # Architecture Decision Records
 ## Client
@@ -123,29 +123,16 @@ This repo is used to capture architectural and design decisions as a reference o
 
 ## When to write an ADR
 
-Not every little decision needs an ADR, and we are not overly prescriptive about the format apart from the initial header format.
-The kind of change that should have an ADR are ones likely to impact many client libraries, server configuration, security, deployment
-and those where we specifically wish to solicit wider community input.
+We use this repository in a few ways:
 
-For a background of the rationale driving ADRs see [Documenting Architecture Decisions](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) by
-Michael Nygard
+ 1. Design specifications where a single document captures everything about a feature, examples are ADR-8, ADR-32, ADR-37 and ADR-40
+ 1. Guidance on conventions and design such as ADR-6 which documents all the valid naming rules
+ 1. Capturing design that might impact many areas of the system such as ADR-2
+
+We want to move away from using these to document individual minor decisions, moving instead to spec like documents that are living documents and can change over time. Each capturing revisions and history.
 
 ## Template
 
 Please see the [template](adr-template.md). The template body is a guideline. Feel free to add sections as you feel appropriate. Look at the other ADRs for examples. However the initial Table of metadata and header format is required to match.
 
 After editing / adding a ADR please run `go run main.go > README.md` to update the embedded index. This will also validate the header part of your ADR.
-
-## Related Repositories
-
- * Server [nats-server](https://github.com/nats-io/nats-server)
- * Reference implementation [nats.go](https://github.com/nats-io/nats.go)
- * Java Client [nats.java](https://github.com/nats-io/nats..java)
- * .NET / C# client [nats.net](https://github.com/nats-io/nats.net)
- * JavaScript [nats.ws](https://github.com/nats-io/nats.ws) [nats.deno](https://github.com/nats-io/nats.deno)
- * C Client [nats.c](https://github.com/nats-io/nats.c)
- * Python3 Client for Asyncio [nats.py](https://github.com/nats-io/nats.py)
-
-### Client Tracking
-
-There is a [Client Feature Parity](https://docs.google.com/spreadsheets/d/1VcYcKqwOp8h8zZwNSRXMS5wrdA1jZz6AumMTHZbXrmY/edit#gid=1032495336) spreadsheet that tracks the clients somewhat, but it is not guaranteed to be complete or up to date.


### PR DESCRIPTION
After feedback that the journal approach of the typical ADR system is not a good format for aiding development of clients we are refocussing this repository around specifications and larger, living, documents.

We will remain flexible in what goes in here - being useful is what matters, the journal style did not work.

Future PRs might update old ADRs and combine them into later ones marking the old ones as such.