### PR TITLE
Add update consumer to simplification ADR

### DIFF
--- a/adr/ADR-37.md
+++ b/adr/ADR-37.md
@@ -46,8 +46,10 @@ Example set of methods on JetStreamContext:
   - `deleteStream(streamName)`
   - `listStreams()`
 - Consumer operations:
-  - `addConsumer(streamName, consumerConfig)`
   - `getConsumer(streamName, consumerName)`
+  - `createConsumer(streamName, consumerConfig)`
+  - `updateConsumer(streamName, consumerConfig)`
+  - `createOrUpdateConsumer(streamName, consumerConfig)`
   - `deleteConsumer(streamName, consumerName)`
 - `accountInfo()`
 
@@ -61,8 +63,10 @@ messages. Streams also allow for and managing consumers.
 Example set of methods on Stream:
 
 - operations on consumers:
-  - `addConsumer(consumerConfig)`
   - `getConsumer(consumerName)`
+  - `createConsumer(consumerConfig)`
+  - `updateConsumer(consumerConfig)`
+  - `createOrUpdateConsumer(consumerConfig)`
   - `deleteConsumer(consumerName)`
 - operations a stream:
   - `purge(purgeOpts)`


### PR DESCRIPTION
Adds info about update API for consumers in simplification, but without whole API spec, as this is not part of this ADR.

It, however, should be, to become a spec.
API spec will be added in separate PR.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>