### PR TITLE
TLS handshake supported server version

### DIFF
--- a/adr/ADR-40.md
+++ b/adr/ADR-40.md
@@ -58,7 +58,7 @@ This method is available in all NATS Server versions.
 
 ##### TLS First (Implicit TLS)
 
-This method has been available since NATS Server 2.11.
+This method has been available since NATS Server 2.10.11
 
 There are two prerequisites to use this method:
 1. Server config has enabled `handshake_first` field in the `tls` block.

--- a/adr/ADR-40.md
+++ b/adr/ADR-40.md
@@ -58,7 +58,7 @@ This method is available in all NATS Server versions.
 
 ##### TLS First (Implicit TLS)
 
-This method has been available since NATS Server 2.10.11
+This method has been available since NATS Server 2.10.4
 
 There are two prerequisites to use this method:
 1. Server config has enabled `handshake_first` field in the `tls` block.


### PR DESCRIPTION
TLS handshake supported server version - Looked like it would only be supported for teh upcoming 2.11. But going back 2.10 releasese its obvious the meant to say 2.10.11