### PR TITLE
[Update] ADR-8 Duplicate Window

### DIFF
--- a/adr/ADR-8.md
+++ b/adr/ADR-8.md
@@ -352,6 +352,9 @@ Here is a full example of the `CONFIGURATION` bucket with compression enabled:
 }
 ```
 
+Note: Previous revisions of this document noted that "Duplicate window must be same as `max_age` when `max_age` is less than 2 minutes".
+This behavior requires no code on the client. As long as `duplicate_window` is not supplied in the configuration, the server will supply this logic.
+
 #### Storing Values
 
 Writing a key to the bucket is a basic JetStream request.

--- a/adr/ADR-8.md
+++ b/adr/ADR-8.md
@@ -307,7 +307,6 @@ A bucket is a Stream with these properties:
  * Safe key purges that deletes history requires rollup to be enabled for the stream using `rollup_hdrs`
  * Write replicas are File backed and can have a varying R value
  * Key TTL is managed using the `max_age` key
- * Duplicate window must be same as `max_age` when `max_age` is less than 2 minutes
  * Maximum value sizes can be capped using `max_msg_size`
  * Maximum number of keys cannot currently be limited
  * Overall bucket size can be limited using `max_bytes`
@@ -337,7 +336,6 @@ Here is a full example of the `CONFIGURATION` bucket with compression enabled:
   "storage": "file",
   "discard": "new",
   "num_replicas": 1,
-  "duplicate_window": 120000000000,
   "rollup_hdrs": true,
   "deny_delete": true,
   "allow_direct": true,


### PR DESCRIPTION
## Change
Removed notes on duplicate window. No need to even write duplicate window on kv config since
1. The server will figure it out
2. The user could change it from the cli anyway

## Justification
This suggestion is made given the behavior of server code (stream.go)...
- If duplicate_window is supplied in the configuration while creating a stream, the server will return an error if it is smaller than the max_age
- If duplicate_window is not supplied, the server will automatically set duplicate window to the smaller of 2 minutes or max_age

## Action
Clients can remove sending duplicate_window to the server when creating a KV bucket or can validate that the behavior is correct like here: https://github.com/nats-io/nats.go/blob/98430acd80423b776149f29d625d158f490ac3c5/jetstream/kv.go#L334-L342