### PR TITLE
Normalize links to other ADR documents

### DIFF
--- a/adr/ADR-10.md
+++ b/adr/ADR-10.md
@@ -22,7 +22,7 @@ the following JSON:
 }
 ```
 
-The `error` field is an [ApiError](0007-error-codes.md). The `success` field will be set to `true` if the request
+The `error` field is an [ApiError](ADR-7.md). The `success` field will be set to `true` if the request
 succeeded. The `purged` field will be set to the number of messages that were
 purged from the stream.
 

--- a/adr/ADR-2.md
+++ b/adr/ADR-2.md
@@ -134,7 +134,7 @@ Advisories must include additional fields:
 Any `message` can have an optional `error` property if needed and can be specified in the JSON Schema,
 they are not a key part of the type hint system which this ADR focus on.
 
-In JetStream [ADR 0001](0001-jetstream-json-api-design.md) we define an error message as this:
+In JetStream [ADR 0001](ADR-1.md) we define an error message as this:
 
 ```
 {

--- a/adr/ADR-28.md
+++ b/adr/ADR-28.md
@@ -47,7 +47,7 @@ The following validation rules for RePublish option apply:
 * A single token as `>` wildcard is allowed as the Source with meaning taken as any stream-ingested subject.
 * Destination MUST have at least 1 non-wildcard token
 * Destination MAY not match or subset the subject filter(s) of the stream 
-* Source and Destination must otherwise comply with requirements specified in [ADR-30 Subject Transform](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-30.md). 
+* Source and Destination must otherwise comply with requirements specified in [ADR-30 Subject Transform](ADR-30.md).
 
 Here is an example of a stream configuration with the RePublish option specified:
 ```text
@@ -77,7 +77,7 @@ RePublish Destination, taken together with RePublish Source, form a valid subjec
 transform is applied to each ingested message (that matches Source configuration) to determine the the concrete 
 RePublish Subject.
 
-See [ADR-30 Subject Transform](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-30.md) for
+See [ADR-30 Subject Transform](ADR-30.md) for
 description of subject transformation as used by RePublish.
  
 ### RePublish Headers

--- a/adr/ADR-32.md
+++ b/adr/ADR-32.md
@@ -39,7 +39,8 @@ Service configuration relies on the following:
 - `description` - a human-readable description about the service (optional)
 - `metadata` - (optional) an object of strings holding free form metadata about
   the deployed instance implemented consistently with
-  [Metadata for Stream and Consumer ADR-33](ADR-33.md). Must be immutable once set.
+  [Metadata for Stream and Consumer ADR-33](ADR-33.md). Must be immutable once
+  set.
 - `statsHandler` - an optional function that returns unknown data that can be
   serialized as JSON. The handler will be provided the endpoint for which it is
   building a `EndpointStats`

--- a/adr/ADR-41.md
+++ b/adr/ADR-41.md
@@ -23,7 +23,7 @@ This describes a feature of the NATS Server 2.11 that allows messages to be trac
 
 ## Prior Work
 
-NATS supports tracking latency of Request-Reply service interactions, this is documented in [ADR-3](adr/ADR-3.md).
+NATS supports tracking latency of Request-Reply service interactions, this is documented in [ADR-3](ADR-3.md).
 
 ## Design
 

--- a/adr/ADR-8.md
+++ b/adr/ADR-8.md
@@ -49,7 +49,7 @@ additional behaviors will come during the 1.x cycle.
  * Custom Stream Names and Stream ingest subjects to cater for different domains, mirrors and imports
  * Key starting with `_kv` is reserved for internal use
  * CLI tool to manage the system as part of `nats`, compatible with client implementations
- * Accept arbitrary application prefixes, as outlined in [ADR-19](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-19.md)
+ * Accept arbitrary application prefixes, as outlined in [ADR-19](ADR-19.md)
  * Data Compression for NATS Server 2.10
 
 ### 1.1


### PR DESCRIPTION
Links to other ADR documents were normalized based off of relative directories which GitHub supports:

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes#relative-links-and-image-paths-in-readme-files