### PR TITLE
ADR-50: Update expected check specifics

### DIFF
--- a/adr/ADR-50.md
+++ b/adr/ADR-50.md
@@ -45,7 +45,7 @@ Clients can decide to optimise the empty acks by only sending a request every N 
 
  * Server will reject messages for which the batch is unknown with a error Pub Ack
  * If messages in a batch is received and any gap is detected the batch will be rejected with a error Pub Ack
- * Check properties like `ExpectedLastSeq` using the sequences found in the stream prior to the batch, at the time when the batch is committed under lock for consistency. Rejects the batch with a error Pub Ack if any message fails these checks
+ * Check properties like `ExpectedLastSeq` using the sequences found in the stream prior to the batch, at the time when the batch is committed under lock for consistency. Rejects the batch with an error Pub Ack if any message fails these checks. Only the first message of the batch may contain `Nats-Expected-Last-Sequence` or `Nats-Expected-Last-Msg-Id`. Checks using `Nats-Expected-Last-Subject-Sequence` can only be performed if prior entries in the batch not also write to that same subject.
  * Abandon without error reply anywhere a batch that has not had messages for 10 seconds, an advisory will be raised on abandonment in this case
  * Send a pub ack on the final message that includes a new property `Batch:ID` and `Count:10`. The sequence in the ack would be the final message sequence, previous messages in the batch would be the preceding sequences
 


### PR DESCRIPTION
Update wording around restrictions for how `Nats-Expected-Last-Sequence`, `Nats-Expected-Last-Msg-Id`, and `Nats-Expected-Last-Subject-Sequence` are handled.

Relates to https://github.com/nats-io/nats-server/pull/7060