### PR TITLE
ADR-60: JetStream reliable stream sourcing/mirroring on WQ/Interest streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This repository captures Architecture, Design Specifications and Feature Guidanc
 |-----|----|-----------|
 |[ADR-50](adr/ADR-50.md)|jetstream, server, client, 2.12, 2.14|JetStream Batch Publishing|
 |[ADR-51](adr/ADR-51.md)|jetstream, 2.12, 2.14|JetStream Message Scheduler|
+|[ADR-60](adr/ADR-60.md)|jetstream, client, server, 2.14|JetStream reliable stream sourcing/mirroring on WQ/Interest streams (updating [ADR-59](adr/ADR-59.md))|
 
 ## Client
 
@@ -68,6 +69,7 @@ This repository captures Architecture, Design Specifications and Feature Guidanc
 |[ADR-54](adr/ADR-54.md)|jetstream, client, spec, orbit, kv|KV Codecs (updating [ADR-8](adr/ADR-8.md))|
 |[ADR-57](adr/ADR-57.md)|jetstream, client, spec, kv|KV Subject Transforms (updating [ADR-8](adr/ADR-8.md))|
 |[ADR-58](adr/ADR-58.md)|jetstream, client, kv|Key-Value Store Roadmap and future considerations (updating [ADR-8](adr/ADR-8.md))|
+|[ADR-60](adr/ADR-60.md)|jetstream, client, server, 2.14|JetStream reliable stream sourcing/mirroring on WQ/Interest streams (updating [ADR-59](adr/ADR-59.md))|
 
 ## Jetstream
 
@@ -103,6 +105,7 @@ This repository captures Architecture, Design Specifications and Feature Guidanc
 |[ADR-57](adr/ADR-57.md)|jetstream, client, spec, kv|KV Subject Transforms (updating [ADR-8](adr/ADR-8.md))|
 |[ADR-58](adr/ADR-58.md)|jetstream, client, kv|Key-Value Store Roadmap and future considerations (updating [ADR-8](adr/ADR-8.md))|
 |[ADR-59](adr/ADR-59.md)|server, jetstream, spec|JetStream Stream Sourcing and Mirroring|
+|[ADR-60](adr/ADR-60.md)|jetstream, client, server, 2.14|JetStream reliable stream sourcing/mirroring on WQ/Interest streams (updating [ADR-59](adr/ADR-59.md))|
 
 ## Kv
 
@@ -183,6 +186,7 @@ This repository captures Architecture, Design Specifications and Feature Guidanc
 |[ADR-55](adr/ADR-55.md)|server, 2.12|Trusted Protocol Aware Proxies|
 |[ADR-56](adr/ADR-56.md)|server, 2.12|JetStream Consistency Models|
 |[ADR-59](adr/ADR-59.md)|server, jetstream, spec|JetStream Stream Sourcing and Mirroring|
+|[ADR-60](adr/ADR-60.md)|jetstream, client, server, 2.14|JetStream reliable stream sourcing/mirroring on WQ/Interest streams (updating [ADR-59](adr/ADR-59.md))|
 
 ## Spec
 

--- a/adr/ADR-60.md
+++ b/adr/ADR-60.md
@@ -1,0 +1,252 @@
+# JetStream reliable stream sourcing/mirroring on WQ/Interest streams
+
+| Metadata | Value                           |
+|----------|---------------------------------|
+| Date     | 2026-03-11                      |
+| Author   | @MauriceVanVeen                 |
+| Status   | Implemented                     |
+| Tags     | jetstream, client, server, 2.14 |
+| Updates  | ADR-59                          |
+
+| Revision | Date       | Author          | Info           |
+|----------|------------|-----------------|----------------|
+| 1        | 2026-03-11 | @MauriceVanVeen | Initial design |
+
+## Context and Problem Statement
+
+JetStream streams can be mirrored or sourced from another stream. Usually this is done on separate servers, for example,
+loosely connected as a leaf node. This is achieved by the server creating an ephemeral ordered push consumer using
+`AckNone`. This is really reliable if the stream that's being mirrored/sourced is a Limits stream. If the server detects
+a gap, it recreates the consumer at the sequence it missed. And since the stream is a Limits stream, it will be able to
+recover from the gap since the messages will still be in the stream.
+
+However, if the stream is a WorkQueue or Interest stream, then the use of an ephemeral `AckNone` consumer is problematic
+for two reasons:
+
+- For both WorkQueue and Interest streams any messages that are sent are immediately acknowledged and removed. If this
+  message is not received on the other end, this message will be lost.
+- Additionally, for an Interest stream since the consumer is ephemeral, interest will be lost while there's no active
+  connection between the two servers. This also results in messages being lost.
+
+Reliable stream mirroring/sourcing is required for use cases where WorkQueue or Interest streams are used or desired.
+
+## Design
+
+### Sourcing of WQ/Interest streams
+
+The server should recognize when a stream that's being sourced is a WorkQueue or Interest stream. In that case it
+should "upgrade" the consumer to become a durable consumer. This durable consumer would need to be replicated as well if
+the WorkQueue or Interest stream is replicated too. The server needs to reuse this consumer for the lifetime of the
+mirror/source config and ensure ordered message delivery, as well as performing a best-effort deletion of the sourcing
+consumer if the mirror/source config is removed.
+
+Since these durable consumers will be visible to the user, they should be identifiable:
+
+- Consumers used for mirroring:
+    - Should be named in the form `JS_MIRROR_<suffix>`.
+    - Should have metadata to describe the stream that initiated the mirroring: `_nats.mirror.stream`,
+      `_nats.mirror.acc` and `_nats.mirror.domain` (if a JetStream domain is specified).
+- Consumers used for sourcing:
+    - Should be named in the form `JS_SRC_<suffix>`.
+    - Should have metadata to describe the stream that initiated the sourcing: `_nats.src.stream`, `_nats.src.acc` and
+      `_nats.src.domain` (if a JetStream domain is specified).
+
+The durable consumer used for stream sourcing/mirroring will need to be just as performant as the current ephemeral
+variant. The current ephemeral consumer configuration uses `AckNone` which is problematic for WorkQueue and Interest
+streams. A new `AckPolicy` (`AckFlowControl`) will need to be used to ensure that performance is on par with an
+ordered consumer and the messages are not lost.
+
+### Performance / Consumer configuration
+
+The consumer configuration will closely resemble the ephemeral push consumer variant:
+
+- The consumer will still act as an "ordered push consumer" but it will be durable.
+- Requires `FlowControl` and `Heartbeat` to be set.
+- Uses `AckPolicy=AckFlowControl` instead of `AckNone`.
+- `AckPolicy=AckFlowControl` will function like `AckAll`. The flow control messages (see below) will ack messages rather
+  than the current ack reply format.
+- The receiving server responds with a flow control message, which includes the stream sequence (`Nats-Last-Stream`)
+  and delivery sequence (`Nats-Last-Consumer`) as headers to signal which messages have been successfully stored.
+- The server receiving the flow control response will ack messages based on these stream/delivery sequences. For
+  WorkQueue and Interest streams this may result in messages deletion.
+- Acknowledgements happen based on flow control limits, usually a data window size. But if the stream is idle the
+  `Heartbeat` will also trigger a flow control message to move the acknowledgement floor up.
+- Flow control messages will happen automatically after a certain data size is reached, but can be controlled using the
+  `MaxAckPending` setting. `MaxAckPending` determines the maximum number of pending messages that can be sent before the
+  sourcing pauses. A flow control message will be automatically sent (no need to wait for a `Heartbeat`) so these
+  messages are acknowledged and new messages can be sent as soon as possible.
+- Since acknowledgements happen based on dynamic flow control, it being determined either by data size, `MaxAckPending`
+  or `Heartbeat`, the consumer cannot have an `AckWait` or `BackOff` setting. These fields need to be unset, or an error
+  will be returned.
+- Additionally, `MaxDeliver` must be set to `-1` (infinite) to ensure if some messages are lost in transit, they can
+  still be reliably redelivered.
+
+### Pre-created durable consumer
+
+An alternative to the server creating and managing ephemeral consumers for stream sourcing is the user pre-creating a
+durable consumer that the server will use. The user bringing their own durable consumer for stream sourcing will be
+referenced to as "durable sourcing".
+
+The benefits of using a pre-created durable consumer are that these will be known by to the user and can be monitored.
+This eases the control (and security implications) of the consumer configuration as this consumer will be manually
+created on the server containing the data that will be sourced. Additionally, the consumer can be paused and resumed,
+allowing the sourcing to temporarily stop if desired.
+
+WorkQueue streams don't allow having multiple consumers with overlapping filter subjects. This means that a durable
+consumer used for mirroring/sourcing of a WorkQueue stream, would not allow another overlapping consumer to be created
+used for a different purpose. In that case, an Interest or Limits stream should be used.
+
+Some additional tooling will be required to create the durable consumer with the proper configuration. But through the
+use of a new `AckPolicy=AckFlowControl` field, the server will be able to help enforce the correct configuration.
+
+Additionally, when configuring the stream source, fields like `OptStartSeq`, `OptStartTime`, and `FilterSubject` are not
+allowed when using durable sourcing. Instead, the durable consumer needs to be configured as such:
+
+- Instead of configuring `OptStartSeq` on the source, configure it in the consumer config: `OptStartSeq`.
+- Instead of configuring `OptStartTime` on the source, configure it in the consumer config: `OptStartTime`.
+- Instead of configuring `FilterSubject` on the source, configure it in the consumer config: `FilterSubject`.
+
+All other consumer configuration fields, like `DeliverPolicy` and `ReplayPolicy`, are allowed as long as the constraints
+for durable sourcing are met. This also allows for new use cases that the ephemeral sourcing currently doesn't support:
+
+- Using `DeliverPolicy=last_per_subject` for only sourcing the last message per subject and every update onward.
+- Using `ReplayPolicy=original` to allow sourcing at the speed the messages were received in originally.
+
+### Stream configuration
+
+The stream configuration will largely remain the same, as the servers will recognize when the user tries to mirror or
+source a WorkQueue or Interest stream. However, it will be extended to include details about the consumer that should be
+used for the durable sourcing (if any).
+
+```go
+type StreamSource struct {
+    Name     string                   `json:"name"`
+    Consumer *StreamConsumerSource    `json:"consumer,omitempty"`
+}
+
+type StreamConsumerSource struct {
+    Name           string `json:"name,omitempty"`
+    DeliverSubject string `json:"deliver_subject,omitempty"`
+}
+```
+
+The sourcing config specifies the configuration of the consumer:
+
+```json
+{
+  "stream": "aggregate",
+  "sources": [
+    {
+      "name": "source",
+      "opt_start_seq": 100,
+      "filter_subject": "source.type.>"
+    }
+  ]
+}
+```
+
+The consumer is created and managed by the server doing the sourcing. The user has limited control to define the
+consumer config, for example, by using an optional starting sequence and filter subject. The server will use an
+ephemeral consumer when sourcing from a Limits stream, but will use a durable consumer when sourcing from a WorkQueue or
+Interest stream.
+
+When using durable sourcing, the user pre-creates the durable consumer and configures it to use the proper
+configuration. Providing the highest level of control over both the consumer config and its lifecycle. The starting
+sequence and filter subject need to be configured on the consumer that's used, instead of on the sourcing config. The
+sourcing config is only extended to contain the consumer name and deliver subject.
+
+```json
+{
+  "stream": "aggregate",
+  "sources": [
+    {
+      "name": "source",
+      "consumer": {
+        "name": "source-consumer",
+        "deliver_subject": "source.consumer.deliver.subject"
+      }
+    }
+  ]
+}
+```
+
+These options allow users to choose the best fit for their use case:
+
+- Simplest config and lifecycle control:
+    - Limits stream: ephemeral consumer. The user doesn't manage nor see the consumer when using the JetStream API. It's
+      automatically created and recreated in the background.
+    - WorkQueue or Interest stream: durable consumer. The user doesn't (need to) manage the consumer but can see it when
+      using the JetStream API. It's automatically created in the background when the mirroring/sourcing starts. The
+      consumer is deleted on a best-effort basis if the mirror/source config is removed, however the user may need to
+      manually delete this durable consumer if this fails.
+- Full control over the consumer lifecycle and configuration:
+    - The user pre-creates a durable consumer to be used for the stream mirroring/sourcing.
+    - Intended to be used if the simple stream config approach doesn't fit the use case, primarily for security reasons
+      or to allow more advanced uses of the consumer configuration that's not supported in the sourcing config. Or, in
+      some use cases where the stream that's sourced is bootstrapped along with the durable consumer on a leaf node
+      that's not yet connected to the server or cluster doing the sourcing. Once this connection is established, all
+      available messages will be reliably mirrored/sourced.
+
+It's generally recommended to use sourcing defined in the stream configuration for most use cases, as it's the simplest
+to configure.
+
+### Consumer delivery state reset API
+
+The ordered consumer implementation relies on the consumer's delivery sequence to start at 1 and increment by 1 for
+every delivered message. Gaps are detected by ensuring this delivery sequence increments monotonically. If a gap is
+detected, the consumer delivery state will need to be reset such that the delivery sequence starts at 1 again.
+
+This is a non-issue for the ephemeral ordered push consumer variant as it creates a new consumer starting at the
+expected sequence if a gap is detected. However, the durable consumer must not be deleted and recreated, since that will
+result in losing interest on an Interest stream and subsequently losing messages. Waiting for re-delivery is also not an
+option as this will result in out-of-order delivery.
+
+Therefore, the server will provide an API to reset the consumer delivery state. When the server detects a gap, it will
+call this API to reset the consumer delivery state. The consumer delivery sequence restarts at 1 and re-delivers pending
+messages. Optionally, re-delivery will start from a specified stream sequence.
+
+This reset API, `$JS.API.CONSUMER.RESET.<STREAM>.<CONSUMER>`, will have the following functionality:
+
+- The consumer will be reset, resembling the delivery state of creating a new consumer with `opt_start_seq` set to the
+  specified sequence.
+- The pending and redelivered messages will always be reset.
+- The delivered stream and consumer sequences will always be reset.
+- The ack floor consumer sequence will always be reset.
+- The ack floor stream sequence will be updated depending on the payload. The next message to be delivered is above this
+  new ack floor.
+- An empty payload will reset the consumer's state, but the ack floor stream sequence will remain the same. (This will
+  be used for the durable sourcing consumer after detecting a gap.)
+- A payload of `{"seq":<seq>}` (with `seq>0`) will update the ack floor stream sequence to be one below the provided
+  sequence. The next message to be delivered has a sequence of `msg.seq >= reset.seq`. A zero-sequence will reset the
+  consumer back to its ack floor.
+- Resetting a consumer to a specific sequence will only be allowed on specific consumer configurations.
+    - Only allowed on `DeliverPolicy=all,by_start_sequence,by_start_time`.
+    - If `DeliverPolicy=all`, the reset will always be successful and allow to move forward or backward arbitrarily.
+    - If `DeliverPolicy=by_start_sequence,by_start_time`, the reset will only be successful if
+      `reset.seq >= opt_start_seq`, or if `loadNextMsg(reset.seq).start_time >= opt_start_time`. This is a safety
+      measure to prevent the consumer from being reset to a sequence before what was allowed by the consumer
+      configuration.
+- The response to the reset API call will follow standard JS API conventions. Specifically, returning a "consumer
+  reset" response to not only reset the consumer, but also expose the current configuration and updated delivery state
+  like a "consumer create" response. This is useful for the durable sourcing consumer to confirm the proper
+  configuration is used before allowing the sourcing to happen. As well as generally looking as if the consumer was
+  recreated, this response can then also be kept by clients if they need to keep a cached consumer response.
+- Additionally, the response will contain the `ResetSeq` that the consumer is reset to.
+
+Importantly, the server should also handle the case where a user manually resets the consumer that's used for sourcing.
+The server should handle this gracefully and ensure no messages are lost. However, the user could also reset the
+consumer such that it moves ahead in the stream. The server should also handle this by properly skipping over those
+messages. This is done by noticing the consumer delivery sequence goes back to 1, the server can then skip the messages
+between the received stream sequence and the one it received previously. If instead the user manually resets the
+consumer to go backward, the server should guarantee that mirrored messages are not duplicated.
+
+When the server uses a durable consumer for sourcing of a WorkQueue or Interest stream, the consumer create/update
+request it sends will implicitly also perform a consumer reset.
+
+## Consequences
+
+Client should support the `$JS.API.CONSUMER.RESET.<STREAM>.<CONSUMER>` reset API. Clients should not rely on this call
+to be initiated by the client process, but it potentially being called by another process, by the CLI for example.
+Importantly, clients should not fail when the consumer delivery sequence is not monotonic, except when needed for the
+"ordered consumer" implementations. If the reset API is called for an ordered consumer, the client should detect a gap
+as it would normally and simply recreate the consumer.


### PR DESCRIPTION
Stream sourcing/mirroring on WorkQueue or Interest streams is not reliable due to the use of an ephemeral `AckNone` consumer. This ADR proposes a design for durable stream sourcing/mirroring that works reliably on all stream retention types.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>