### PR TITLE
ADR-43: Absolute Nats-TTL & Nats-Schedule-TTL

### DIFF
--- a/adr/ADR-43.md
+++ b/adr/ADR-43.md
@@ -7,6 +7,12 @@
 | Status   | Implemented                     |
 | Tags     | jetstream, client, server, 2.11 |
 
+| Revision | Date       | Author                      | Info                                                                                       | Server Version |
+|----------|------------|-----------------------------|--------------------------------------------------------------------------------------------|----------------|
+| 1        | 2024-07-11 | @ripienaar                  | Document initial design                                                                    | 2.11.0         |
+| 2        | 2026-04-30 | @ripienaar                  | Add error codes, marker clamping behavior & 2.14 conformance notes                         | 2.14.0         |
+| 3        | 2026-05-22 | @MauriceVanVeen             | Add absolute `@at` timestamp support to `Nats-TTL`                                         | TBD            |
+
 ## Context and motivation
 
 Streams support a one-size-fits-all approach to message TTL based on the MaxAge setting. This causes any message in the Stream to expire at that age.
@@ -34,6 +40,26 @@ below the 1 second minimum (including a literal `0`), will result in an error re
 being discarded.
 
 When a message with the `Nats-TTL` header is published to a stream with the feature disabled the message will be rejected with an error.
+
+### Absolute Timestamps
+
+> [!NOTE]
+> As of Server version 2.14 absolute-timestamp TTLs are not yet implemented.
+
+In addition to a relative duration, the `Nats-TTL` header may carry an absolute expiry time using the `@at` form borrowed from the Message Scheduler (see [ADR-51](ADR-51.md)):
+
+```
+Nats-TTL: @at 2026-06-01T23:00:00Z
+```
+
+This instructs the server to remove the message at the supplied instant rather than a fixed duration after it was stored. The rules for the `@at` form are:
+
+- The time format is RFC3339 and may include a time zone, which the server converts to UTC when received.
+- The server may rewrite the stored header value. For example, normalized to UTC, or clamped up to the `SubjectDeleteMarkerTTL` minimum-effective-TTL floor. But it always remains in `@at <timestamp>` form. It is never converted to a duration or to seconds.
+- The expiry time must be at least 1 second after the message's Stream timestamp. A timestamp in the past is rejected with error `10165` (`invalid per-message TTL`), consistent with the duration minimum.
+- The `@at` form is mutually exclusive with `never` and with a duration value.
+- Because the expiry is an absolute instant rather than an age, an `@at` TTL still expires at the same wall-clock time after a restore or replication, and unlike a duration-valued `Nats-TTL` it keeps that absolute meaning when the message is sourced or mirrored into another stream instead of being re-anchored to the receiving stream's timestamp (see [Sources and Mirrors](#sources-and-mirrors)).
+- Otherwise, an `@at` TTL behaves exactly like a duration-valued `Nats-TTL`: limit markers and the disabled-feature rejection apply unchanged.
 
 ## Limit Markers
 
@@ -113,15 +139,15 @@ Restrictions:
 
 The server returns the following `err_code` values for rejection paths defined in this ADR:
 
-| Rejection path                                                              | `err_code` | Description                                                    |
-|-----------------------------------------------------------------------------|-----------:|----------------------------------------------------------------|
-| Publish with `Nats-TTL` header to a stream where `AllowMsgTTL` is `false`   |    `10166` | `per-message TTL is disabled`                                  |
-| `Nats-TTL` header value is unparsable, sub-second, or a literal `0`         |    `10165` | `invalid per-message TTL`                                      |
-| `SubjectDeleteMarkerTTL` configured below `1s`                              |    `10052` | `subject delete marker TTL must be at least 1 second`          |
-| `SubjectDeleteMarkerTTL` set on a Mirror stream                             |    `10052` | `subject delete markers forbidden on mirrors`                  |
-| `SubjectDeleteMarkerTTL` set with `AllowRollup: false` in pedantic mode     |    `10052` | `subject delete marker cannot be set if roll-ups are disabled` |
-| `SubjectDeleteMarkerTTL` set with `AllowRollup: true` and `DenyPurge: true` |    `10052` | `roll-ups require the purge permission`                        |
-| Stream update attempting to set `AllowMsgTTL: false` after it was `true`    |    `10052` | `message TTL status can not be disabled`                       |
+| Rejection path                                                                       | `err_code` | Description                                                    |
+|--------------------------------------------------------------------------------------|-----------:|----------------------------------------------------------------|
+| Publish with `Nats-TTL` header to a stream where `AllowMsgTTL` is `false`            |    `10166` | `per-message TTL is disabled`                                  |
+| `Nats-TTL` header value is unparsable, sub-second, `0`, or an `@at` time in the past |    `10165` | `invalid per-message TTL`                                      |
+| `SubjectDeleteMarkerTTL` configured below `1s`                                       |    `10052` | `subject delete marker TTL must be at least 1 second`          |
+| `SubjectDeleteMarkerTTL` set on a Mirror stream                                      |    `10052` | `subject delete markers forbidden on mirrors`                  |
+| `SubjectDeleteMarkerTTL` set with `AllowRollup: false` in pedantic mode              |    `10052` | `subject delete marker cannot be set if roll-ups are disabled` |
+| `SubjectDeleteMarkerTTL` set with `AllowRollup: true` and `DenyPurge: true`          |    `10052` | `roll-ups require the purge permission`                        |
+| Stream update attempting to set `AllowMsgTTL: false` after it was `true`             |    `10052` | `message TTL status can not be disabled`                       |
 
 All `10052` (`JSStreamInvalidConfigF`) responses share a common shape — the description field carries the underlying reason as enumerated above.
 

--- a/adr/ADR-51.md
+++ b/adr/ADR-51.md
@@ -7,15 +7,16 @@
 | Status   | Approved              |
 | Tags     | jetstream, 2.12, 2.14 |
 
-| Revision | Date       | Author                      | Info                                                                                       | Server Version |
-|----------|------------|-----------------------------|--------------------------------------------------------------------------------------------|----------------|
-| 1        | 2025-03-21 | @ripienaar                  | Document Initial Design                                                                    | 2.12.0         |
-| 2        | 2025-09-30 | @ripienaar                  | Use `omitempty` on configuration fields                                                    | 2.12.0         |
-| 3        | 2026-01-05 | @MauriceVanVeen             | Support time zones for cron                                                                | 2.14.0         |
-| 4        | 2026-04-08 | @ripienaar, @MauriceVanVeen | Add `Nats-Schedule-Rollup` & document stopping schedules                                   | 2.14.0         |
-| 5        | 2026-04-20 | @MauriceVanVeen             | Clarify `Nats-Schedule-Source` on no messages                                              | 2.14.0         |
-| 6        | 2026-04-23 | @MauriceVanVeen             | Clarify stream retention interaction & auto-applied rollup                                 | 2.14.0         |
-| 7        | 2026-04-28 | @ripienaar                  | Document `Nats-Schedule-Time-Zone` format, `@every` minimum & `Nats-Scheduler` error 10212 | 2.14.0         |
+| Revision | Date       | Author                      | Info                                                                                        | Server Version |
+|----------|------------|-----------------------------|---------------------------------------------------------------------------------------------|----------------|
+| 1        | 2025-03-21 | @ripienaar                  | Document Initial Design                                                                     | 2.12.0         |
+| 2        | 2025-09-30 | @ripienaar                  | Use `omitempty` on configuration fields                                                     | 2.12.0         |
+| 3        | 2026-01-05 | @MauriceVanVeen             | Support time zones for cron                                                                 | 2.14.0         |
+| 4        | 2026-04-08 | @ripienaar, @MauriceVanVeen | Add `Nats-Schedule-Rollup` & document stopping schedules                                    | 2.14.0         |
+| 5        | 2026-04-20 | @MauriceVanVeen             | Clarify `Nats-Schedule-Source` on no messages                                               | 2.14.0         |
+| 6        | 2026-04-23 | @MauriceVanVeen             | Clarify stream retention interaction & auto-applied rollup                                  | 2.14.0         |
+| 7        | 2026-04-28 | @ripienaar                  | Document `Nats-Schedule-Time-Zone` format, `@every` minimum & `Nats-Scheduler` error 10212  | 2.14.0         |
+| 8        | 2026-05-22 | @MauriceVanVeen             | Accept `@at` `Nats-Schedule-TTL`; require it after an `@at` schedule, forbid with repeating | TBD            |
 
 ## Context and Motivation
 
@@ -50,6 +51,13 @@ Messages produced from this kind of schedule will have a `Nats-Schedule-Next` he
 The generated message has a Message TTL of `5m`.
 
 The time format is RFC3339 and may include a timezone which the server will convert to UTC when received and execute according to UTC time later.
+
+`Nats-Schedule-TTL` accepts the same values of `Nats-TTL` as defined in [ADR-43](ADR-43.md), which is applied verbatim to the generated message as `Nats-TTL: <value>`. However, there are rules around the `@at` syntax when using the `Nats-Schedule-TTL` header:
+
+- `Nats-Schedule: @at <schedule-time>` publishes a single message at an absolute time, as shown above.
+- `Nats-Schedule-TTL: @at <ttl-time>` gives the generated message an absolute `Nats-TTL: @at <ttl-time>` rather than a duration.
+- When both `Nats-Schedule` and `Nats-Schedule-TTL` use `@at`, the TTL time must be at least 1 second after the schedule time. The generated message is published at the schedule time, so a TTL time equal to, before, or less than 1 second after it would yield a message that is already expired or below the 1 second per-message TTL minimum. Such a schedule is rejected as an invalid pattern when published.
+- `Nats-Schedule-TTL: @at` may only be combined with a single `@at` schedule. Combining it with a repeating schedule (`@every`, predefined, or Cron) is rejected as an invalid pattern, because a fixed absolute expiry would make every generated message expire at the same instant and later messages immediately expire. Use a duration-form `Nats-Schedule-TTL` with repeating schedules.
 
 There may only be one message per subject that holds a schedule, if a user wishes to have many delayed messages all publishing into the same subject the scheduled messages need to go into something like `orders.schedule.UUID` where UUID is a unique identifier, set the `Nats-Schedule-Target` to the desired target subject.
 
@@ -145,18 +153,18 @@ These headers can be set on message that define a schedule:
 | `Nats-Schedule`           | The schedule the message will be published on                                                                                                                                                                                               |
 | `Nats-Schedule-Target`    | The subject the message will be delivered to                                                                                                                                                                                                |
 | `Nats-Schedule-Source`    | Instructs the schedule to read the last message on the given subject and publish it to the target. If no message exists on the source subject, the schedule's own body and headers is published as a fallback. Wildcards are not supported. |
-| `Nats-Schedule-TTL`       | When publishing sets a TTL on the message if the stream supports per message TTLs                                                                                                                                                           |
+| `Nats-Schedule-TTL`       | When publishing sets a TTL on the generated message if the stream supports per message TTLs. Accepts a duration or the absolute `@at <timestamp>` form (see [ADR-43](ADR-43.md) and the `@at` rules above).                                 |
 | `Nats-Schedule-Time-Zone` | The time zone used for the Cron schedule. If not specified, the Cron schedule will be in UTC. Not allowed to be used if the schedule is not a Cron schedule.                                                                                |
 | `Nats-Schedule-Rollup`    | When publishing sets a Rollup on the message, only `sub` is a valid value                                                                                                                                                                   |
 
 Messages that the Schedules produce will have these headers set in addition to any other headers on that was found in the message.
 
-| Header               | Description                                                                              |
-|----------------------|------------------------------------------------------------------------------------------|
-| `Nats-Scheduler`     | The subject holding the schedule                                                         |
-| `Nats-Schedule-Next` | Timestamp for next invocation for cron schedule messages or `purge` for delayed messages |
-| `Nats-TTL`           | `5m` when `Nats-Schedule-TTL` is given with value `5m`                                   |
-| `Nats-Rollup`        | `sub` when `Nats-Schedule-Rollup` is set to `sub`                                        |
+| Header               | Description                                                                                       |
+|----------------------|---------------------------------------------------------------------------------------------------|
+| `Nats-Scheduler`     | The subject holding the schedule                                                                  |
+| `Nats-Schedule-Next` | Timestamp for next invocation for cron schedule messages or `purge` for delayed messages          |
+| `Nats-TTL`           | `5m` when `Nats-Schedule-TTL` is `5m`; `@at 2026-06-01T23:00:00Z` when the absolute form is given |
+| `Nats-Rollup`        | `sub` when `Nats-Schedule-Rollup` is set to `sub`                                                 |
 
 The body of the message will simply be the provided body in the schedule.
 


### PR DESCRIPTION
Add an absolute timestamp form to per-message TTL, just like the `Nats-Schedule: @at <ts>` pattern.

When using a schedule that needs to trigger `@every` interval, it was tricky to specify for exactly how long this should happen. You could define `Nats-TTL` as 1 week converted to seconds or a duration string, but then when the schedule stops would depend on when it was persisted. If you want it to stop on Monday before 11:00, then that's really tricky. Supporting an absolute timestamp solves that.

Similarly for use cases where you define `Nats-Schedule` to trigger on a specific `@at` timestamp and you want the resulting delayed message to expire at an exact timestamp. You would need to use the timestamp when you want it to expire, subtract the trigger time from it, convert that to a duration, and encode that in `Nats-Schedule-TTL`. Being able to pass an absolute timestamp in the per-message TTL makes these use cases significantly simpler.

There are of course guardrails:
- An absolute TTL can't be in the past.
- when used in conjunction with `Nats-Schedule: @at <ts>`, the `Nats-Schedule-TTL` (if also absolute)  needs to be at least one second after when the schedule triggers.
- Using a repeating schedule with an absolute `Nats-Schedule-TTL` is not allowed and errors, otherwise the schedule would outlive this TTL and each scheduled message after it would immediately expire.